### PR TITLE
Fix atomic css config usage

### DIFF
--- a/atomic/Gulpfile.js
+++ b/atomic/Gulpfile.js
@@ -13,7 +13,7 @@ gulp.task('acss', function(filepath) {
         cached('*.html'),
         acss({
           outfile: 'style.css',
-          acssConfig: require('./config.js'),
+          acssConfig: Object.assign({}, require('./config.js')),
         }),
         remember('*.html'),
         gulp.dest('./')


### PR DESCRIPTION
gulp-atomizer config doesn't work well with gulp watch

Case:

1. run `gulp watch`
2. edit html, add class e.g `C(red`) => got `.C\(red\) {color: red}` in css, everything is ok
3. change `C(red)` to `C(green)` => got both `C\(red\) {color: red}` and `.C\(green\) {color: green}`


Details here https://gist.github.com/idmytro/7ff9d8dcb4ec08cefe477ce8cec47c89

