### PR TITLE
Issue #8 rewrite 'bem' example with sass - links highlighting fixing

### DIFF
--- a/bem-css/index.html
+++ b/bem-css/index.html
@@ -48,7 +48,7 @@
                     <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-css/" class="nav__link nav__link--active">BEM CSS</a>
                 </li>
                 <li class="nav__item">
-                    <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-sass/" class="nav__link nav__link--active">BEM SASS</a>
+                    <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-sass/" class="nav__link">BEM SASS</a>
                 </li>
                 <li class="nav__item">
                     <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-flexboxgrid/" class="nav__link">BEM Flexbox Grid</a>

--- a/bem-sass/index.html
+++ b/bem-sass/index.html
@@ -45,7 +45,7 @@
                     <a href="https://aleshaoleg.github.io/holy-grail-markup/organic" class="nav__link">Organic</a>
                 </li>
                 <li class="nav__item">
-                    <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-css/" class="nav__link nav__link--active">BEM CSS</a>
+                    <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-css/" class="nav__link">BEM CSS</a>
                 </li>
                 <li class="nav__item">
                     <a href="https://aleshaoleg.github.io/holy-grail-markup/bem-sass/" class="nav__link nav__link--active">BEM SASS</a>


### PR DESCRIPTION
While duplicating css link I didn't edit the highlighting for necessary methodology